### PR TITLE
thermostat: data-set (default "desired-temp") in this.o.reading

### DIFF
--- a/js/fhem-tablet-ui.js
+++ b/js/fhem-tablet-ui.js
@@ -132,9 +132,11 @@ $( document ).ready(function() {
 		var device = $(this).attr('device');  
 		//default reading parameter name
 		$(this).data('get', $(this).data('get') || 'desired-temp');
+		$(this).data('set', $(this).data('set') || 'desired-temp');
 		$(this).data('temp', $(this).data('temp') || 'measured-temp');
 		
 		knob_elem.knob({
+			'reading': $(this).data('set'),
 			'min':10,
 			'max':30,
 			'height':100,
@@ -157,7 +159,7 @@ $( document ).ready(function() {
 			'release' : function (v) { 
 			  if (ready){
 				setFhemStatus(device, this.o.reading + ' ' + v);
-				$.toast('Set '+ device + this.o.reading + ' ' + v );
+				$.toast('Set '+ device + ' ' + this.o.reading + ' ' + v );
 				this.$.data('curval', v);
 			  }
 			}	


### PR DESCRIPTION
Fehler beschrieben ab: http://forum.fhem.de/index.php/topic,34233.msg272197.html#msg272197, vorgeschlagene Lösung in http://forum.fhem.de/index.php/topic,34233.msg272411.html#msg272411.

Die "reading"-Zeile hat bei Thermostaten gefehlt, daher wurde 'set <device> undefined <value>" an fhem gesendet.
