### PR TITLE
"Add to Homescreen" Funktion

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
 	 */
 	-->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+	<meta name="mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="widget_base_width" content="116">
 	<meta name="widget_base_height" content="131">
 	<meta name="longpoll" content="1">


### PR DESCRIPTION
Die beiden Meta-Tags sorgen dafür, dass man in Android und iOS Verknüpfungen auf dem Homescreen anlegen kann, die den Browser im Fullscreen-Modus starten. Für Android ist der Meta-Tag eigentlich veraltet, aber bisher vollkommen ausreichend (https://developer.chrome.com/multidevice/android/installtohomescreen).
