### PR TITLE
data-fix Default 1 entfernt

### DIFF
--- a/js/fhem-tablet-ui.js
+++ b/js/fhem-tablet-ui.js
@@ -310,9 +310,9 @@ function update(filter) {
 				var part =  $(this).data('part') || -1;
 				var unit = ($(this).data('unit')) ? unescape($(this).data('unit')) : '';
 				var fix =  $(this).data('fix');
-				fix = ( $.isNumeric(fix) ) ? fix : 1;
+				fix = ( $.isNumeric(fix) ) ? fix : -1;
 				var val = getPart(value,part);
-				val = ( $.isNumeric(val) ) ? Number(val).toFixed(fix) : val;
+				val = ( $.isNumeric(val) && fix>=0 ) ? Number(val).toFixed(fix) : val;
 				$(this).html( val + "<span style='font-size: 50%;'>"
 													+unit+"</span>" );
 			 }


### PR DESCRIPTION
isNumeric() interpretiert Strings aus Ziffern mit einer führenden Null (zB Telefonnummern) als numerische Werte. Das führt in Kombination mit dem Default 1 für data-fix dazu, dass ein label, dass eine Telefonnummer "012345" anzeigen soll, statt dessen "12345.0" anzeigt. Sowohl das Abschneiden der führenden 0, als auch das Anhängen der Nachkommastelle möchte man in dem Fall nicht haben.

Problem: Das Standardverhalten für data-fix wird verändert, evtl. müssen User nachträglich data-fix="1" setzen.
Alternative: Ein neues Attribut data-string mit Default 0, das bei Wert 1 dafür sorgt, dass val in einen String gecastet wird.

Die Alternative finde ich extrem unschön und ich würde dazu tendieren die wahrscheinlich nur vereinzelt auftretenden Nacharbeiten in Kauf zu nehmen.
