### PR TITLE
Leerzeichen nach Doppelpunkt in Eventstrings ist optional

### DIFF
--- a/js/fhem-tablet-ui.js
+++ b/js/fhem-tablet-ui.js
@@ -219,7 +219,7 @@ function longPoll(roomName) {
 					var lines = data.replace(/<br>/g,"").split(/\n/);
 					var regDevice = /\s[0-2][0-9]:[0-5][0-9]:[0-5][0-9]\s(\S*)\s(\S*)\s(.*)/;
 					var regDate = /^([0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-2][0-9]:[0-5][0-9]:[0-5][0-9])\s/;
-					var regParaname = /^(\S{3,}):\s(.*)$/;
+					var regParaname = /^(\S{3,}):\s?(.*)$/;
 					lines.pop(); //remove last empty line
 					
 					for (var i=currLine; i < lines.length; i++) {


### PR DESCRIPTION
Wenn ein Reading auf Leerstring gesetzt wird, ist der Event-String nach dem Doppelpunkt zuende. Dadurch das \s nicht optional war, wurden zugehörige Events falsch als STATE-Updates interpretiert und die Readings wurden nicht upgedatet (d.h. "zurück gesetzte" Werte behalten in UI ihren alten Wert). Mit \s? wird der Wert für das Reading korrekt geleert. Allerdings weiss nicht ob die Änderung Seiteneffekte haben könnte.

Konkret tritt der Fehler im Zusamenhang mit dem XBMC Modul auf. Beim Wechsel von TV Show zu Musik bleibt currentShowtitle gesetzt und umgekehrt bleiben currentArtist und currentAlbum gesetzt.
