### PR TITLE
Präzisierung longpoll Regex

### DIFF
--- a/js/fhem-tablet-ui.js
+++ b/js/fhem-tablet-ui.js
@@ -231,7 +231,7 @@ function longPoll(roomName) {
 					var lines = data.replace(/<br>/g,"").split(/\n/);
 					var regDevice = /\s[0-2][0-9]:[0-5][0-9]:[0-5][0-9]\s(\S*)\s(\S*)\s(.*)/;
 					var regDate = /^([0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-2][0-9]:[0-5][0-9]:[0-5][0-9])\s/;
-					var regParaname = /^(\S{3,}):\s?(.*)$/;
+					var regParaname = /^(\S{3,}):(?:\s(.*))?$/;
 					lines.pop(); //remove last empty line
 					
 					for (var i=currLine; i < lines.length; i++) {


### PR DESCRIPTION
Die Änderung aus https://github.com/knowthelist/fhem-tablet-ui/pull/8 hat dazu geführt, dass STATE-Updates mit Doppelpunkten innerhalb der ersten drei Zeichen  ("set TIMER1 22:34:01") falsch interpretiert und dadurch ignoriert wurden. Die Änderung ist wieder näher am ursprünglichen Regex und behebt beide Fehler.
