### PR TITLE
"!on" in data-get-off als negiertes data-get-on

### DIFF
--- a/js/widget_switch.js
+++ b/js/widget_switch.js
@@ -17,6 +17,8 @@ var widget_switch = {
 		var elem = $(this).famultibutton({
 			icon: 'fa-lightbulb-o',
 			backgroundIcon: 'fa-circle',
+			onBackgroundColor:$(this).data('color')||'#aa6900',
+            		offBackgroundColor:$(this).data('offcolor')||'#505050',
 			offColor: '#2A2A2A',
 			onColor: '#2A2A2A',
 			
@@ -49,6 +51,8 @@ var widget_switch = {
 				else if ( state.match(RegExp('^' + $(this).data('get-on') + '$')) )
 					$(this).data('famultibutton').setOn();
 				else if ( state.match(RegExp('^' + $(this).data('get-off') + '$')) )
+					$(this).data('famultibutton').setOff();
+				else if ( $(this).data('get-off')=='!on' && state != $(this).data('get-on') )
 					$(this).data('famultibutton').setOff();
 			}
 		}


### PR DESCRIPTION
Die Regex-Syntax zum negieren eines Wertes ist komplex und meistens wird nur der Fall "Gegenteil von get-on" gebraucht. Den könnte man mit dem Keyword "!on" abfangen. Sollte irgendwo tatsächlich der Wert "!on" gebraucht werden, wird er vorher verglichen - sollte also kein Problem sein.

Die Hintergrundfarben haben damit nichts zu tun, die Änderung lag hier nur grade rum.
