### PR TITLE
IE Kompatibilitätsmodus abschalten

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 	<meta name="widget_base_height" content="131">
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="longpoll" content="1"> <!-- 1=longpoll;0=shortpoll every 30sec -->
 	<meta name="debug" content="0"> <!-- 1=output to console;0=not output -->
 	


### PR DESCRIPTION
IE nutzt ansonsten für Intranetsites die Renderingengine aus IE7
