### PR TITLE
Verwendung als data-cmd="{perlSub()}"

### DIFF
--- a/js/widget_push.js
+++ b/js/widget_push.js
@@ -16,11 +16,11 @@ var widget_push = {
 			
 			// Called in toggle on state.
 			toggleOn: function( ) {
-				  if( device && typeof device != "undefined") {
-					 var cmd = [$(this).data('cmd'), device, $(this).data('set')].join(' ');
-				     setFhemStatus(cmd);
-				     TOAST && $.toast(cmd);
-				   }
+				var cmd = [$(this).data('cmd'), device, $(this).data('set')].join(' ');
+				setFhemStatus(cmd);
+				if( device && typeof device != "undefined") {
+					TOAST && $.toast(cmd);
+				}
 			},
 
 	 	 });


### PR DESCRIPTION
Das push-Widget ist auch geeignet um Perl Subs  in fhem zu starten. Das wurde durch die Änderung nach https://github.com/knowthelist/fhem-tablet-ui/pull/28 verhindert.
