### PR TITLE
function loadplugin(plugin, success, error)

### DIFF
--- a/www/tablet/js/fhem-tablet-ui.js
+++ b/www/tablet/js/fhem-tablet-ui.js
@@ -30,18 +30,11 @@ var plugins = {
     this.modules.push(module);
   },
   load: function (name) {
-  	$.ajax({
-		url: dir+'/'+name+'.js',
-		dataType: "script",
-		cache: true,
-		async: false,
-		context:{name: name},
-		success: function () { 
-				DEBUG && console.log('Loaded plugin: '+this.name);
-				var module = eval(this.name);
-				plugins.addModule(module);
-				module.init();
-		},
+  	loadplugin(name, function () { 
+		DEBUG && console.log('Loaded plugin: '+ name);
+		var module = eval(name);
+		plugins.addModule(module);
+		module.init();
 	});
   },
   update: function (dev,par) {
@@ -332,6 +325,21 @@ function requestFhem(paraname) {
  		}
 	});
 
+}
+
+function loadplugin(plugin, success, error) {
+    dir = $('script[src$="fhem-tablet-ui.js"]').attr('src');
+    var name = dir.split('/').pop(); 
+    dir = dir.replace('/'+name,"");
+    $.ajax({
+        url: dir + '/'+plugin+'.js',
+        dataType: "script",
+        cache: true,
+        async: false,
+        context:{name: name},
+        success: success||function(){ return true },
+        error: error||function(){ return false },
+    });
 }
 
 this.getPart = function (s,p) {


### PR DESCRIPTION
Ich experimentiere grade mit JS "Vererbung" via $.extend(). Dazu benötige ich innerhalb der Widgets die Möglichkeit Widgets nachzuladen. Sieht dann so aus:

```
if(typeof widget_volume == 'undefined') {
    loadplugin('widget_volume');
}
```

Die eigentliche "Vererbung" ($.extend() merged Objekte) sieht dann so aus:

```
var widget_settimer = $.extend({}, widget_volume, {
    _settimer: null,
    elements: null,
    init: function() {
}
```

In dem Beispiel kann ich mir die Neudefinition von drawDial sparen. Das sollte den Code insgesamt wartbarer machen.
