### PR TITLE
Datum im Regex optional?

### DIFF
--- a/www/tablet/js/fhem-tablet-ui.js
+++ b/www/tablet/js/fhem-tablet-ui.js
@@ -334,7 +334,7 @@ function requestFhem(paraname) {
   	})
   	.done (function( data ) {
 			var lines = data.replace(/\n\)/g,")\n").split(/\n/);
-            var regCapture = /^(\S*)\s*([0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-2][0-9]:[0-5][0-9]:[0-5][0-9])?\.?[0-9]{0,3}\s+(.*)$/;
+             var regCapture = /^(\S*)\s*([0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-2][0-9]:[0-5][0-9]:[0-5][0-9])\.?[0-9]{0,3}\s+(.*)$/;
 			for (var i=0; i < lines.length; i++) {
                 var date,key,val;
 				var line = $.trim( lines[i] );


### PR DESCRIPTION
Folgendes Problem: Hat ein Reading keinen Wert, wird der Timestamp ins Wertefeld übernommen. Kann man nachvollziehen indem man getParameter um console.log(params[paraname]) erweitert. Verursachend ist mMn der Regex auf line in requestFhem, da dort die zweite Gruppe, die auf den Timestamp matcht optional ist - oder gibt es dafür einen anderen Hintergrund den ich übersehe? Es gibt da offenbar einen Zusammenhang mit der Logik in Zeile 344 - if(groups.length>2) - ich habe nur nirgend ein Reading ohne Datum gesehen, von daher war groups.length in meinen Tests immer > 2. Langer Rede, kurzer Sinn: Wenn diese Änderung nicht machbar ist, müsste anders sicher gestellt werden, dass der Timestamp nicht "nach vorne" rutscht.
