### PR TITLE
init_ui: return elem

### DIFF
--- a/www/tablet/js/widget_famultibutton.js
+++ b/www/tablet/js/widget_famultibutton.js
@@ -37,6 +37,7 @@ var widget_famultibutton = $.extend({}, widget_widget, {
             toggleOn: function() { base.toggleOn(elem) },
             toggleOff: function() { base.toggleOff(elem) },
         });
+        return elem;
     },
     init: function () {
         var base = this;


### PR DESCRIPTION
Ausserhalb von init_ui war ich nicht in der Lage auf die famultibutton-Funktionen (insb. setOn()) zuzugreifen. Ich hatte erwartet, dass ich - nach dem Aufruf von init_ui -  $(this).setOn() verwenden könnte, geht aber nicht. Ich nehme an, dass elem kein Pointer, sondern eine Kopie von $(this) ist - call by reference kann JS offenbar nicht, von daher ist eine Rückgabe der Kopie anscheinend die einzige Möglichkeit. Bessere Ideen sind sehr willkommen.
