### PR TITLE
widget_select: data-alias

### DIFF
--- a/www/tablet/js/widget_select.js
+++ b/www/tablet/js/widget_select.js
@@ -41,7 +41,8 @@ var widget_select = {
 	deviceElements.each(function(index) {  
         if ( $(this).data('get')==par || $(this).data('list')==par){
 			var state = getDeviceValue( $(this), 'get' );
-            var items = $(this).data('items')
+            var items = $(this).data('items');
+            var alias = $(this).data('alias')||$(this).data('items');
             if (!jQuery.isArray(items)){
                 items = getDeviceValue( $(this), 'list' );
                 if (items){
@@ -67,7 +68,7 @@ var widget_select = {
                 if (select_elem){
                     select_elem.empty();
                     for (var i=0;i<items.length;i++) {
-                        select_elem.append('<option value='+items[i]+'>'+items[i]+'</option>');
+                        select_elem.append('<option value='+items[i]+'>'+(alias[i]||items[i])+'</option>');
                     }
                 }
             }


### PR DESCRIPTION
data-alias ermöglicht die Verwendung von Aliasen für Items:

```
<div data-type="select" 
        data-device="MCP_KODI" 
        data-items='["http://www.deutschlandradio.de/streaming/dlf.m3u","smb://SKY/share/playlist/tormentedradio.m3u","smb://SKY/share/playlist/dkultur.m3u"]' 
        data-alias='["DLF","tormentedradio"]'
        data-set="open"></div>
```

Erzeugt ein Select mit den Einträgen

```
DLF
tormentedradio
smb://SKY/share/playlist/dkultur.m3u
```

gesendet wird aber immer der Stream-URL aus data-items.
