### PR TITLE
widget_symbol: default values for get-on/-off

### DIFF
--- a/www/tablet/js/widget_symbol.js
+++ b/www/tablet/js/widget_symbol.js
@@ -9,14 +9,18 @@ var widget_symbol = $.extend({}, widget_famultibutton, {
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));
-            $(this).data('off-color', $(this).data('off-color') || '#505050');
-            $(this).data('off-background-color', $(this).data('off-background-color') || '#505050');
-            $(this).data('on-color', $(this).data('on-color') || '#aa6900');
-            $(this).data('on-background-color', $(this).data('on-background-color') || '#aa6900');
-            $(this).data('background-icon', $(this).data('background-icon') || null);
-            $(this).data('icon', $(this).data('icon') || (( $.isArray($(this).data('icons')) )?$(this).data('icons')[0]:'fa-windows'));
+            $(this).data('off-color',               $(this).attr('data-off-color')              || '#505050');
+            $(this).data('off-background-color',    $(this).attr('data-off-background-color')   || '#505050');
+            $(this).data('on-color',                $(this).attr('data-on-color')               || '#aa6900');
+            $(this).data('on-background-color',     $(this).attr('data-on-background-color')    || '#aa6900');
+            $(this).data('background-icon',         $(this).attr('data-background-icon')        || null);
+            $(this).data('icon',                    $(this).attr('data-icon')                   || (( $.isArray($(this).data('icons')) )?$(this).data('icons')[0]:'fa-windows'));
+            $(this).data('get-on',                  $(this).attr('data-get-on')                 || 'open');
+            $(this).data('get-off',                 $(this).attr('data-get-off')                || 'closed');
             $(this).data('mode', 'signal');
             base.init_ui($(this));
+            
+            console.log($(this).data('device') + ' ' + $(this).data('get-on'));
         });
     },
 });


### PR DESCRIPTION
Die Defaults füt get-on, get-off hatte ich vergessen. Ausserdem alle Zuweisungen nach base.init_attr() auf .attr() umgeschrieben. Ansonsten kann es passieren, dass der durch die base-Klasse vorgegebene Default nicht überschrieben wird, weil $(this).data() eben diesen zurück liefert.
