### PR TITLE
widget_famultibutton: Vereinfachung der Default-Werte Logik

### DIFF
--- a/www/tablet/js/widget_famultibutton.js
+++ b/www/tablet/js/widget_famultibutton.js
@@ -21,12 +21,13 @@ var widget_famultibutton = $.extend({}, widget_widget, {
         }
     },
     init_attr : function(elem) {
-        elem.data('get',        elem.data('get') || 'STATE');
-        elem.data('cmd',        elem.data('cmd') || 'set');
-        elem.data('get-on',     elem.attr('data-get-on')?elem.data('get-on'):(elem.attr('data-on') || 'on'));
-        elem.data('get-off',    elem.attr('data-get-off')?elem.data('get-off'):(elem.attr('data-off') || 'off'));        elem.data('set-on',     elem.attr('data-set-on')    || elem.data('get-on'));
-        elem.data('set-off',    elem.attr('data-set-off')   || elem.data('get-off'));
-        elem.data('mode',       elem.data('mode')|| 'toggle');
+        elem.data('get',        elem.data('get')        || 'STATE');
+        elem.data('cmd',        elem.data('cmd')        || 'set');
+        elem.data('get-on',     elem.data('get-on')     || 'on');
+        elem.data('get-off',    elem.data('get-off')    || 'off');
+        elem.data('set-on',     elem.data('set-on')     || elem.data('get-on'));
+        elem.data('set-off',    elem.data('set-off')    || elem.data('get-off'));
+        elem.data('mode',       elem.data('mode')       || 'toggle');
         readings[elem.data('get')] = true;
     },
     init_ui : function(elem) {


### PR DESCRIPTION
Damit müssen Default-Werte vom ableitenden Widget vordefiniert werden, d.h. bevor base.init_attr() in .init() aufgerufen wird festgelegt sein. Patch für widget_symbol folgt.
