### PR TITLE
widget_symbol: Vereinfachung der Default-Werte Logik

### DIFF
--- a/www/tablet/js/widget_symbol.js
+++ b/www/tablet/js/widget_symbol.js
@@ -8,14 +8,16 @@ var widget_symbol = $.extend({}, widget_famultibutton, {
         var base = this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
-            base.init_attr($(this));
-            $(this).data('off-color', $(this).data('off-color') || '#505050');
-            $(this).data('off-background-color', $(this).data('off-background-color') || '#505050');
-            $(this).data('on-color', $(this).data('on-color') || '#aa6900');
-            $(this).data('on-background-color', $(this).data('on-background-color') || '#aa6900');
-            $(this).data('background-icon', $(this).data('background-icon') || null);
-            $(this).data('icon', $(this).data('icon') || (( $.isArray($(this).data('icons')) )?$(this).data('icons')[0]:'fa-windows'));
+            $(this).data('off-color',               $(this).data('off-color')           || '#505050');
+            $(this).data('off-background-color',    $(this).data('off-background-color')|| '#505050');
+            $(this).data('on-color',                $(this).data('on-color')            || '#aa6900');
+            $(this).data('on-background-color',     $(this).data('on-background-color') || '#aa6900');
+            $(this).data('background-icon',         $(this).data('background-icon')     || null);
+            $(this).data('icon',                    $(this).data('icon')                || (( $.isArray($(this).data('icons')) )?$(this).data('icons')[0]:'fa-windows'));
+            $(this).data('get-on',                  $(this).data('get-on')              || 'open');
+            $(this).data('get-off',                 $(this).data('get-off')             || 'closed');
             $(this).data('mode', 'signal');
+            base.init_attr($(this));
             base.init_ui($(this));
         });
     },


### PR DESCRIPTION
Damit werden Default-Werte definiert, bevor base.init_attr() aufgerufen wird (siehe https://github.com/knowthelist/fhem-tablet-ui/pull/64). 

Die Defaults für get-on, get-off hatte ich vergessen.
