### PR TITLE
widget_push als Child von widget_famultibutton

### DIFF
--- a/www/tablet/js/widget_push.js
+++ b/www/tablet/js/widget_push.js
@@ -1,49 +1,23 @@
-var widget_push = {
-  _push: null,
-  elements: null,
-  init: function () {
-  	_push=this;
-  	_push.elements = $('div[data-type="push"]');
- 	_push.elements.each(function(index) {
+if(typeof widget_famultibutton == 'undefined') {
+    loadplugin('widget_famultibutton');
+}
 
-		var device = $(this).data('device');
-		$(this).data('cmd', $(this).data('cmd') || 'set');
-		var elem = $(this).famultibutton({
-			backgroundIcon: 'fa-circle-thin',
-			offColor: '#505050',
-			onColor: '#aa6900',
-			mode: 'push', 
-			
-			// Called in toggle on state.
-			toggleOn: function( ) {
-				var cmd = [$(this).data('cmd'), device, $(this).data('set')].join(' ');
-				setFhemStatus(cmd);
-				if( device && typeof device != "undefined") {
-					TOAST && $.toast(cmd);
-				}
-			},
+var widget_push = $.extend({}, widget_famultibutton, {
+    widgetname : 'push',
+    init: function () {
+        var base = this;
+        this.elements = $('div[data-type="'+this.widgetname+'"]');
+        this.elements.each(function(index) {
+            $(this).data('device',          $(this).data('device')          || ' ');
+            $(this).data('off-color',       $(this).data('off-color')       || '#505050');
+            $(this).data('on-color',        $(this).data('on-color')        || '#aa6900');
+            $(this).data('background-icon', $(this).data('background-icon') || 'fa-circle-thin');
+            $(this).data('set-on',          $(this).data('set-on')          || $(this).data('set') || ' '); 
+            $(this).data('set-off',         $(this).data('set-off')         || $(this).data('set') || ' ');
+            $(this).data('mode', 'push');
 
-	 	 });
-	});
-  },
-  update: function (dev,par) {
-
-    var deviceElements= _push.elements.filter('div[data-device="'+dev+'"]');
-    deviceElements.each(function(index) {
-        if ( $(this).data('get')==par){
-			var value = getDeviceValue( $(this), 'get' );
-			if (value){
-				var part =  $(this).data('part') || -1;
-				var unit = ($(this).data('unit')) ? unescape($(this).data('unit')) : '';
-				var fix =  $(this).data('fix');
-				fix = ( $.isNumeric(fix) ) ? fix : 1;
-				var val = getPart(value,part);
-				val = ( $.isNumeric(val) ) ? Number(val).toFixed(fix) : val;
-				$(this).html( val + "<span style='font-size: 50%;'>"
-													+unit+"</span>" );
-			 }
-		}
-	});
-   }
-			 
-};
+            base.init_attr($(this));
+            base.init_ui($(this));
+        });
+    },
+});


### PR DESCRIPTION
Analaog zu widget_symbol jetzt widget_push auch von widget_famultibutton abgeleitet.
Bekannter Unterschied zur Vorversion: push reagiert jetzt auch auf Zustandsänderungen des Devices (wenn angegeben). In der Vorversion war eine update-Function enthalten, die anscheinend aus dem label-Widget übernommen war und keinen Effekt auf das push-Widget hatte. Jetzt wird die update-Function von famultibutton verwendet. Falls die Änderung unerwünscht ist, kann eine leere update-Funktion angelegt werden

```
update: function() {},
```
