### PR TITLE
widget_circlemenu: data-close-after / 1s pro Menüeintrag

### DIFF
--- a/www/tablet/js/widget_circlemenu.js
+++ b/www/tablet/js/widget_circlemenu.js
@@ -24,7 +24,7 @@ var widget_circlemenu= {
                         timeoutMenu=setTimeout(function(){
                             elem.close();
                             setTimeout(function(){showModal(false);},1000);
-                        },4000);
+                        },parent.data('close-after')||Math.max(4000, 1000*(parent.find('li').length-1)));
                     }
                    showModal(true);
                 },


### PR DESCRIPTION
Mit data-close-after kann die Schliesszeit festgelegt werden. Die zweite Änderung ist eine Dynamisierung der Schliesszeit und evtl. Geschmackssache: Das Menü wird damit 4 Sekunden bis [Anzahl Menüeinträge] Sekunden aufgehalten.
