### PR TITLE
fhem-tablet-ui.js: dynamicload()

### DIFF
--- a/www/tablet/js/fhem-tablet-ui.js
+++ b/www/tablet/js/fhem-tablet-ui.js
@@ -377,11 +377,15 @@ function requestFhem(paraname) {
 }
 
 function loadplugin(plugin, success, error, async) {
-    dir = $('script[src$="fhem-tablet-ui.js"]').attr('src');
+    dynamicload('js/'+plugin+'.js', success, error, async);
+}
+
+function dynamicload(file, success, error, async) {
+    var dir = $('script[src$="fhem-tablet-ui.js"]').attr('src');
     var name = dir.split('/').pop(); 
     dir = dir.replace('/'+name,"");
     $.ajax({
-        url: dir + '/'+plugin+'.js',
+        url: dir + '/../' + file,
         dataType: "script",
         cache: true,
         async: async || false,
@@ -389,10 +393,6 @@ function loadplugin(plugin, success, error, async) {
         success: success||function(){ return true },
         error: error||function(){ return false },
     });
-}
-
-function loadplugin_async(plugin, success, error) {
-    return loadplugin(plugin, success, error, true);
 }
 
 function loadStyleSchema(){


### PR DESCRIPTION
Generische Funktion zum nachladen von allem. Damit können Plugins genauso wie Libraries nachgeladen werden. loadplugin() ist damit nur noch ein Shorthand für die generischere dynamicload(). In https://github.com/nesges/Widgets-for-fhem-tablet-ui/blob/master/testing/widget_clicksound.js verwende ich dynamicload() um eine Library nachzuladen. Damit könnte man sich ein paar  <script> Tags im HTML sparen.

loadplugin_async() hatte ich einmal angelegt, aber ich brauche sie gar nicht - wenn du sie ebenfalls nicht brauchst, sollte sie mMn weg.
