### PR TITLE
widget_weather: data-device-type

### DIFF
--- a/www/tablet/js/widget_weather.js
+++ b/www/tablet/js/widget_weather.js
@@ -59,6 +59,7 @@ var widget_weather = $.extend({}, widget_widget, {
         "sonnig":                       "B",
         "Schnee":                       "U",
         'Schneeregen':                  'V',
+        'unterschiedlich bewoelkt, vereinzelt Schauer und Gewitter': 'Q',
         
         // OPENWEATHER (Wetter.com) (incomplete)
         'leichter Schnee - Schauer' :   'U',
@@ -126,6 +127,7 @@ var widget_weather = $.extend({}, widget_widget, {
         "sonnig":                       'sunny.png',
         "Schnee":                       'snow.png',
         'Schneeregen':                  'rainsnow.png',
+        'unterschiedlich bewoelkt, vereinzelt Schauer und Gewitter': 'scatteredshowers.png',
         
         // OPENWEATHER (wetter.com) (incomplete)
         'leichter Schnee - Schauer' :   'chance_of_snow.png',
@@ -309,10 +311,32 @@ var widget_weather = $.extend({}, widget_widget, {
 
                     //wheater icons
                     $(this).empty();
-                    // translate val to ':key'
-                    var translation = base.translationmap[val];
-                    while(typeof mapped != "undefined" && !mapped.match(/^:/)) {
-                        translation = base.translationmap[mapped];
+                    
+                    var device_type;
+                    if($(this).data('device-type')) {
+                        device_type = $(this).data('device-type');
+                    } else {
+                        if(par.match(/^fc\d+_weather(Day|Evening|Morning|Night)$/)) {
+                            device_type='PROPLANTA';
+                        } else if(par.match(/^fc\d+_condition$/)) {
+                            device_type='Weather';
+                        } else if(par.match(/^fc\d+_weather\d*$/)) {
+                            device_type='OPENWEATHER';
+                        } else if(par.match(/^fc\d+_weatherCode\d*$/)) {
+                            device_type='OPENWEATHER';
+                        } else {
+                            device_type='UNKNOWN';
+                        }
+                    }
+                    
+                    console.log(device_type);
+                    
+                    if(device_type != 'PROPLANTA') {
+                        // translate val to ':key'
+                        var translation = base.translationmap[val];
+                        while(typeof mapped != "undefined" && !mapped.match(/^:/)) {
+                            translation = base.translationmap[mapped];
+                        }
                     }
 
                     var mapped = typeof translation == "undefined"?val:translation;


### PR DESCRIPTION
Mit data-device-type kann der Modultyp des gelesenen Devices gesetzt werden. Aktuell wird damit nur für PROPLANTA verhindert, dass eine Übersetzung durchgeführt wird. Ist data-device-type nicht gesetzt, wird versucht den Device-Typ aus dem Readingnamen zu schliessen.
