### PR TITLE
fhem-tablet-ui.js: Uncaught SyntaxError: Invalid regular expression: /+/...

### DIFF
--- a/www/tablet/js/fhem-tablet-ui.js
+++ b/www/tablet/js/fhem-tablet-ui.js
@@ -521,7 +521,7 @@ this.indexOfNumeric = function(array,val){
 
 this.indexOfRegex = function(array,find){
   for (var i=0;i<array.length;i++) {
-      var match = find.match(new RegExp(array[i]));
+      var match = find.match(new RegExp(array[i].replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&")));
       if (match)
             return i
   }


### PR DESCRIPTION
In der ausgetauschten Zeile wird ein unbekannter Regex aus der Konfiguration angewendet. Sonderzeichen (zB "+") im Regex führen u.U. zu der o.g. Fehlermeldung. Der Regex müsste escaped werden. Lösung laut http://stackoverflow.com/questions/2593637/how-to-escape-regular-expression-in-javascript - habe ich nicht intensiv getestet, bei mir waren die Fehler danach behoben.
