### PR TITLE
README: HTTPSRV URL um index.html ergänzt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Requires
 Install
 -------
  * copy the whole tree into the corresponding folder of your FHEM server /\<fhem-path\>/www/tablet
- * add 'define tablet_ui HTTPSRV tablet/ ./www/tablet Tablet Frontend' in fhem.cfg
+ * add 'define tablet_ui HTTPSRV tablet/index.html ./www/tablet Tablet Frontend' in fhem.cfg
  * rename the index-example.html to index.html or create your own index.html
  * Tadaaa! A new fhem ui in http://\<fhem-url\>:8083/fhem/tablet/
  


### PR DESCRIPTION
Um mit HTTPSRV auf der sicheren Seite zu sein, muss der URL bis aufs File angegeben werden. Problembeschreibung in  http://forum.fhem.de/index.php/topic,36122.msg294007.html#msg294007
