### PR TITLE
fhem-tablet-ui.js: initReadingsArray + requestFhem

### DIFF
--- a/www/tablet/js/fhem-tablet-ui.js
+++ b/www/tablet/js/fhem-tablet-ui.js
@@ -169,6 +169,7 @@ function initReadingsArray(get) {
             readings[reading] = true;
             pars.push(reading);
         }
+        requestFhem(reading);
     }
 }
 
@@ -201,12 +202,6 @@ function initWidgets() {
     //init widgets
     for (var widget_type in types) {
         plugins.load('widget_'+widget_type);
-    }
-
-    //get current values of readings
-    DEBUG && console.log('Request readings from FHEM');
-    for (var reading in readings) {
-        requestFhem(reading);
     }
 }
 


### PR DESCRIPTION
Für mit initReadingsArray initialisierte data-Attribute muss requestFhem aufgerufen wurden. Für data-get passierte das nachgelagert in dem Block ab Zeile 206. Da initReadingsArray in Widgets direkt aufgerufen wird, muss requestFhem innerhalb der Funktion aufgerufen werden. Ansonsten würden Readings aus nicht-data-get-Attributen nicht berücksichtigt.

Problem: Dadurch wird requestFhem beim ersten laden zu oft aufgerufen, nämlich bei gleichnamigen Readings jedes mal, anstatt nur einmalig nach Ermitteln aller Readings.

Alternativ müsste man diese Änderung verwerfen und den Widgets den Aufruf von requestFhem() überlassen. In dem Fall würde ich requestFhem() einen optionalen, zweiten Parameter "device" verpassen.

Was meinst du?
