### PR TITLE
widget_famultibutton: bugfix (ohne device kein setFhemstatus)

### DIFF
--- a/www/tablet/js/widget_famultibutton.js
+++ b/www/tablet/js/widget_famultibutton.js
@@ -146,15 +146,15 @@ var widget_famultibutton = $.extend({}, widget_widget, {
                 break;
             case 'url-xhr':
                 if( device && typeof device != "undefined" && device !== " ") {
-                    $.get(target);
                     TOAST && $.toast(target);
                 }
+                $.get(target);
                 break;
             case 'fhem-cmd':
                 if( device && typeof device != "undefined" && device !== " ") {
-                    setFhemStatus(target);
                     TOAST && $.toast(target);
                 }
+                setFhemStatus(target);
                 break;
         }
     },


### PR DESCRIPTION
Bin grade skeptisch, ob man die Toasts überhaupt unterdrücken sollte. Ich fand das mal chick, aber es ist intransparent.
