### PR TITLE
Make all 'base' variables local, add new ones where necessary.

### DIFF
--- a/www/tablet/js/widget_image.js
+++ b/www/tablet/js/widget_image.js
@@ -18,7 +18,7 @@ var widget_image = $.extend({}, widget_widget, {
         readings[$(this).data('get')] = true;
     },
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));

--- a/www/tablet/js/widget_knob.js
+++ b/www/tablet/js/widget_knob.js
@@ -36,7 +36,7 @@ var widget_knob = $.extend({}, widget_widget, {
         elem.data('tkcolor', elem.data('tkcolor') || '#666');
     },
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));
@@ -99,6 +99,7 @@ var widget_knob = $.extend({}, widget_widget, {
     },
     update: function (dev,par) {
         var deviceElements;
+        var base=this;
         if ( dev == '*' )
             deviceElements= this.elements;
         else

--- a/www/tablet/js/widget_simplechart.js
+++ b/www/tablet/js/widget_simplechart.js
@@ -12,7 +12,7 @@ var widget_simplechart = {
        return res.join(' ');
     },
   init: function () {
-      base=this;
+      var base=this;
       this.elements = $('div[data-type="'+this.widgetname+'"]');
       this.elements.each(function(index) {
 

--- a/www/tablet/js/widget_thermostat.js
+++ b/www/tablet/js/widget_thermostat.js
@@ -147,7 +147,7 @@ var widget_thermostat = $.extend({}, widget_knob, {
   return false;
 },
   init: function () {
-  	base=this;
+  	var base=this;
 	this.elements=$('div[data-type="'+this.widgetname+'"]');
 	this.elements.each(function( index ) {
         var knob_elem =  jQuery('<input/>', {

--- a/www/tablet/js/widget_volume.js
+++ b/www/tablet/js/widget_volume.js
@@ -77,7 +77,7 @@ var widget_volume = $.extend({}, widget_knob, {
   return false;
   },
   init: function () {
-  	base=this;
+  	var base=this;
     this.elements = $('div[data-type="'+this.widgetname+'"]');
  	this.elements.each(function(index) {
 		var maxval = $(this).data('max') || 70;
@@ -181,6 +181,7 @@ var widget_volume = $.extend({}, widget_knob, {
   update: function (dev,par) {
 
     var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
+    var base=this;
     isUpdating=true;
     deviceElements.each(function(index) {
 

--- a/www/tablet/js/widget_weather.js
+++ b/www/tablet/js/widget_weather.js
@@ -346,7 +346,7 @@ var widget_weather = $.extend({}, widget_widget, {
     },
     
     init: function () {
-        base=this;
+        var base=this;
         this.elements = $('div[data-type="'+this.widgetname+'"]');
         this.elements.each(function(index) {
             base.init_attr($(this));
@@ -355,7 +355,7 @@ var widget_weather = $.extend({}, widget_widget, {
     },
     
     update: function (dev,par) {
-        base=this;
+        var base=this;
         var deviceElements= this.elements.filter('div[data-device="'+dev+'"]');
         deviceElements.each(function(index) {
             if ( $(this).data('get')==par){


### PR DESCRIPTION
This corrects the usage on the 'base' variables thoughout the code. They are used to keep a reference to the widget object/class thingies and should not be global to prevent race conditions and bugs like nesges/Widgets-for-fhem-tablet-ui#3
