### PR TITLE
Add global setting for weather image path

### DIFF
--- a/www/tablet/js/widget_weather.js
+++ b/www/tablet/js/widget_weather.js
@@ -339,7 +339,8 @@ var widget_weather = $.extend({}, widget_widget, {
         
         var fhem_path = $("meta[name='fhemweb_url']").attr("content") || "/fhem/";
         fhem_path = fhem_path.replace(/\/$/, '');
-        elem.data('image-path', elem.data('image-path') || fhem_path + '/images/default/weather/')
+        var image_path = $("meta[name='weather_image_path']").attr("content") || fhem_path + '/images/default/weather/';
+        elem.data('image-path', elem.data('image-path') || image_path);
         if(!elem.data('image-path').match(/\/$/)) {
             elem.data('image-path', elem.data('image-path')+'/');
         }


### PR DESCRIPTION
If defined, content of meta 'weather_image_path' is used as path for weather images. Overriding individual elements still works. This mechanism helps taking off load from the FHEM server by serving static images from another location. Using the new mechanism avoids the necessity to declare attribute 'image-path' for each element individually.
