### PR TITLE
widget_famultibutton: =='' ist true bei 0

### DIFF
--- a/www/tablet/js/widget_famultibutton.js
+++ b/www/tablet/js/widget_famultibutton.js
@@ -129,7 +129,7 @@ var widget_famultibutton = $.extend({}, widget_widget, {
         }
     },
     toggleOff : function(elem) {
-        if (elem.data('set-off')==''){
+        if (elem.data('set-off')===''){
             elem.setOn();
         }
         else if(this._doubleclicked(elem, 'off')) {


### PR DESCRIPTION
Damit war es unmöglich data-set-off="0" zu senden. ==='' macht die korrekte Typprüfung
