### PR TITLE
widget_popup: draggable deaktivierbar, dynamicload(JQuery UI) nur bei Bedarf

### DIFF
--- a/www/tablet/js/widget_popup.js
+++ b/www/tablet/js/widget_popup.js
@@ -2,9 +2,6 @@ if(typeof widget_widget == 'undefined') {
     dynamicload('js/widget_widget.js');
 }
 
-if (!$.fn.draggable)
-    dynamicload('../pgm2/jquery-ui.min.js', null, null, false);
-
 var widget_popup= $.extend({}, widget_widget, {
     widgetname: 'popup',
     hide: function(elem,mode) {
@@ -57,6 +54,8 @@ var widget_popup= $.extend({}, widget_widget, {
         elem.initData('width'   ,'100%');
         elem.initData('mode'    ,'animate');
         elem.initData('starter' ,null);
+        elem.initData('draggable' ,true);
+        
         elem.addReading('get');
     },
     init: function () {
@@ -73,7 +72,14 @@ var widget_popup= $.extend({}, widget_widget, {
               }).html('x').appendTo(dialog);
 
             if (dialog && close && starter){
-                dialog.draggable();
+                if(elem.data('draggable')) {
+                    if (!$.fn.draggable) {
+                        console.log("widget_popup tries to load jquery ui. insert correct script tag into html header to avoid error (and this warning)")
+                        console.log('e.g.: <script type="text/javascript" src="../pgm2/jquery-ui.min.js"></script>');
+                        dynamicload('../pgm2/jquery-ui.min.js', null, null, false);
+                    }
+                    dialog.draggable();
+                }
                 dialog.css({'height':elem.data('height'),'width':elem.data('width')});
                 starter.css({'cursor': 'pointer'});
                 elem.closest('.gridster>ul>li').css({overflow: 'visible'});


### PR DESCRIPTION
Mit data-draggable="false" lässt sich die JQuery UI-Drag-Funktion für das Popup-Fenster deaktivieren. In dem Fall wird JQuery UI auch gar nicht erst geladen.
