### PR TITLE
Fix an Bug when a Stylepart has a float value

### DIFF
--- a/www/tablet/js/fhem-tablet-ui.js
+++ b/www/tablet/js/fhem-tablet-ui.js
@@ -513,7 +513,7 @@ function loadStyleSchema(){
                var elmName = rules[r].selectorText;
                var params = {};
                for (var s in styles){
-                   var param = styles[s].split(':');
+                   var param = styles[s].toString().split(':');
                    if (param[0].match(/color/)){
                       params[$.trim(param[0])]=$.trim(param[1]).replace('! important','').replace('!important','');
                    }


### PR DESCRIPTION
In rare cases, the following error message appears
"TypeError: styles[s].split is not a function"
