### PR TITLE
widget_label: Attribut "hide" zum dynamischen verstecken

### DIFF
--- a/www/tablet/js/widget_label.js
+++ b/www/tablet/js/widget_label.js
@@ -75,6 +75,25 @@ var widget_label = $.extend({}, widget_widget, {
             var value = (elem.hasClass('timestamp'))
                         ?elem.getReading('get').date
                         :elem.getReading('get').val;
+
+            // hide element when it's value equals data-hide
+            // if data-hideparents is set, it is interpreted als jquery selector to hide elements parents filtered by this selector
+            if(elem.data('hide')) {
+                if(value == elem.data('hide')) {
+                    if(elem.data('hideparents')) {
+                        elem.parents(elem.data('hideparents')).hide();
+                    } else {
+                        elem.hide();
+                    }
+                } else {
+                    if(elem.data('hideparents')) {
+                        elem.parents(elem.data('hideparents')).show();
+                    } else {
+                        elem.show();
+                    }
+                }
+            }
+
             if (value){
                 var part = elem.data('part');
                 var val = getPart(value,part);


### PR DESCRIPTION
data-hide wird mit value verglichen, bei Gleichheit wird das label versteckt. Ist data-hideparents gesetzt, werden alle Elternelemente, die den in data-hideparents gesetzten Selektor matchen, ebenfalls versteckt. Beispiel:

 <tr id="timer_row">
     <td rowspan="2" width="1" style="vertical-align:top">
         <i class="fa nesges-alarmclock"></i>
     </td>
     <td colspan="3"><div style="color:rgb(170,105,0)" 
         data-type="label" 
         data-hide="-"
         data-hideparents="#timer_row"
         data-device="TIMER1"></div></td>
 </tr>

Die Zeile wird ausgeblendet, wenn TIMER1 den Wert "-" hat.
