### PR TITLE
Bugfix. X-Button hidden, Popup with swiper

### DIFF
--- a/www/tablet_eval/css/fhem-tablet-ui.css
+++ b/www/tablet_eval/css/fhem-tablet-ui.css
@@ -261,6 +261,7 @@ header.fixed#header-nav + main#panel{
   right: 2%;
   text-decoration: none;
   color: #bbb;
+  z-index:10;
 }
 
 .dialog-close:hover {


### PR DESCRIPTION
If a swiper widget is placed in a popup, the X button of the popup is hidden.
