### PR TITLE
Option TOAST_NOSTACK added

### DIFF
--- a/www/tablet_eval/js/fhem-tablet-ui.js
+++ b/www/tablet_eval/js/fhem-tablet-ui.js
@@ -152,6 +152,7 @@ var ftui = {
         ftui.config.debuglevel  = $("meta[name='debug']").attr("content") || 0;
         ftui.config.DEBUG = ( ftui.config.debuglevel>0 );
         ftui.config.TOAST  = ($("meta[name='toast']").attr("content") != '0');
+        ftui.config.TOAST_NOSTACK  = ($("meta[name='toast_nostack']").attr("content") == '1');
         ftui.config.shortpollInterval  = $("meta[name='shortpoll-only-interval']").attr("content") || 30;
         //self path
         ftui.config.dir = $('script[src*="fhem-tablet-ui"]').attr('src');
@@ -905,18 +906,23 @@ var ftui = {
     toast: function(text,error){
         //https://github.com/kamranahmedse/jquery-toast-plugin
         if (ftui.config.TOAST){
+            var tstack = 5;
+            if(ftui.config.TOAST_NOSTACK)
+                tstack = false;
             if (error && error === 'error')
                 $.toast({
                     heading: 'Error',
                     text: text,
                     hideAfter: 20000,   // in milli seconds
                     icon: 'error',
-                    loader: false
+                    loader: false,
+                    stack: tstack
                 })
             else
                 $.toast({
                     text:text,
                     loader: false
+                    stack: tstack
                  });
 
         }

--- a/www/tablet_eval/js/fhem-tablet-ui.js
+++ b/www/tablet_eval/js/fhem-tablet-ui.js
@@ -151,8 +151,7 @@ var ftui = {
         ftui.config.DEMO = ($("meta[name='demo']").attr("content") == '1');
         ftui.config.debuglevel  = $("meta[name='debug']").attr("content") || 0;
         ftui.config.DEBUG = ( ftui.config.debuglevel>0 );
-        ftui.config.TOAST  = ($("meta[name='toast']").attr("content") != '0');
-        ftui.config.TOAST_NOSTACK  = ($("meta[name='toast_nostack']").attr("content") == '1');
+        ftui.config.TOAST  = $("meta[name='toast']").attr("content") || 5; //1,2,3...= n Toast-Messages, 0: No Toast-Messages
         ftui.config.shortpollInterval  = $("meta[name='shortpoll-only-interval']").attr("content") || 30;
         //self path
         ftui.config.dir = $('script[src*="fhem-tablet-ui"]').attr('src');
@@ -905,9 +904,9 @@ var ftui = {
 
     toast: function(text,error){
         //https://github.com/kamranahmedse/jquery-toast-plugin
-        if (ftui.config.TOAST){
-            var tstack = 5;
-            if(ftui.config.TOAST_NOSTACK)
+        if (ftui.config.TOAST != 0){
+            var tstack = ftui.config.TOAST;
+            if(ftui.config.TOAST == 1)
                 tstack = false;
             if (error && error === 'error')
                 $.toast({

--- a/www/tablet_eval/js/fhem-tablet-ui.js
+++ b/www/tablet_eval/js/fhem-tablet-ui.js
@@ -921,7 +921,7 @@ var ftui = {
             else
                 $.toast({
                     text:text,
-                    loader: false
+                    loader: false,
                     stack: tstack
                  });
 


### PR DESCRIPTION
Ich denke ich habe einen Kompromiss gefunden um die Toast-Messages nicht vollständig abschalten zu müssen.
meta name="toast_nostack" content="1"
0 oder nicht angegeben: Toast-Messages werden wie immer angezeigt.
1: Es wird höchstens eine Toast-Message angezeigt.
Die Toast-Config sollte dir ja aber geläufig sein. :)

Schau es dir an... Würde mich freuen.
