### PR TITLE
added factor, suffix and postfix feature [label widget]

### DIFF
--- a/www/tablet/js/widget_label.js
+++ b/www/tablet/js/widget_label.js
@@ -33,6 +33,18 @@ var Modul_label = function () {
         return ( $.isNumeric(value) && fix>=0 ) ? Number(value).toFixed(fix) : value;
     };
 
+    function update_factor(value, factor) {
+        return ( $.isNumeric(value) && $.isNumeric(factor) ) ? (Number(value) * Number(factor)).toString() : value;
+    };
+
+    function update_postfix(value, postfix) {
+        return postfix ? value + postfix : value;
+    };
+
+    function update_prefix(value, prefix) {
+        return prefix ? prefix + value : value;
+    };
+
     function update_substitution(value, substitution) {
         ftui.log(3,me.widgetname+' - value:'+value+', substitution:'+substitution);
         if(substitution){
@@ -113,7 +125,10 @@ var Modul_label = function () {
                 var unit = elem.data('unit');
 
                 val = update_substitution(val, elem.data('substitution'));
+                val = update_factor(val, elem.data('factor'));
                 val = update_fix(val, elem.data('fix'));
+                val = update_prefix(val, elem.data('prefix'));
+                val = update_postfix(val, elem.data('postfix'));
                 if (!isNaN(parseFloat(val)) && isFinite(val) && val.indexOf('.')>-1){
                     var vals = val.split('.');
                     val = "<span class='label-precomma'>"+vals[0]+"</span>" +


### PR DESCRIPTION
- data-factor="<numeric>" ... manipulates numeric value by multiplying
                            value = value \* factor
- data-postfix="<text>"   ... adds postfix to value w/o having to use substitution
                            value = value + postfix
- data-prefix="<text>"    ... adds prefix to value w/o having to use substitution
                            value = prefix + value

Especially data-factor would be nice to have added. I'm using it show the output and energy produced by my photovoltaic system in [kW] instead of [W], and [kWh] instead of [Wh]
