### PR TITLE
Make html link title attribute independant from data-get

### DIFF
--- a/www/tablet/js/widget_link.js
+++ b/www/tablet/js/widget_link.js
@@ -126,6 +126,7 @@ var Modul_link = function () {
         elem.initData('active-border-color', elem.data('border-color'));
         elem.initData('active-background-color', elem.data('background-color'));
         me.addReading(elem, 'get');
+        me.addReading(elem, 'title');
         if (elem.isDeviceReading('lock')) {
             me.addReading(elem, 'lock');
         }
@@ -273,10 +274,16 @@ var Modul_link = function () {
                 var elem = $(this);
                 var val = elem.getReading('get').val;
                 elem.data('url', val);
+            });
+
+        me.elements.filterDeviceReading('title', dev, par)
+            .each(function (index) {
+                var elem = $(this);
+                var val = elem.getReading('title').val;
                 elem.attr('title', val);
             });
 
-        //extra reading for lock
+        // extra reading for lock
         me.elements.filterDeviceReading('lock', dev, par)
             .each(function (idx) {
                 var elem = $(this);


### PR DESCRIPTION
My ui displays rss feed headers as links. I wasn't able to set the title from readings to show the full content of rss on mouseover/as tooltip - here is the fix.

Example:
```

<div class= "blank" data-type="link"
     data-title="RSS_NEWS:n00_description"
     data-color="white"
     data-height="1.5em"
     data-get="RSS_NEWS:n00_link">
 <div class="left" data-type="label" data-device="RSS_NEWS" data-get="n00_title"></div>
</div>
```

Note:
After this update users have to set data-title explicitly to same value of data-get for old behaviour