### PR TITLE
[widget_joinedlabel] style unit with class='label-unit'

### DIFF
--- a/www/tablet/js/widget_joinedlabel.js
+++ b/www/tablet/js/widget_joinedlabel.js
@@ -72,7 +72,7 @@ var Modul_joinedlabel = function () {
 
             var unit = elem.data('unit');
             if (unit) {
-                html += "<span style='font-size: 50%;'>" + unit + "</span>";
+                html += "<span class='label-unit'>" + unit + "</span>";
             }
 
             elem.html(html);


### PR DESCRIPTION
This makes »joinedlabel« behave like »label« and allows to style
the unit via css.