### PR TITLE
Added option to 'data-chop'

### DIFF
--- a/www/tablet/js/widget_klimatrend.js
+++ b/www/tablet/js/widget_klimatrend.js
@@ -59,6 +59,10 @@ var Modul_klimatrend = function () {
                     var sign = text.replace(/^([+-]).*/, '$1');
                     var reading = $(this).data('get');
                     var highmark = 99;
+                    var chop = 1 * $(this).data('data-chop') || 0;
+                    if ( chop > 0 ) {
+                      number = 1 * text.replace(/^([0-9]*).([0-9]).*/, '$1.$2');
+                    }
                     if ($(this).data('highmark')) {
                         highmark = $(this).data('highmark');
                     } else {


### PR DESCRIPTION
If enabled (aka set to >0 ) it will remove any digits past first digit after period.
Statistic module returns values like 0.012345678 - setting data-chop="1" will truncate it to "0.0"
TODO: use values of data-chop to determine where to 'chop off' (e.g. data-chop="2" would render 0.01)