### PR TITLE
Added option "data-chop"

### DIFF
--- a/www/tablet/js/widget_klimatrend.js
+++ b/www/tablet/js/widget_klimatrend.js
@@ -59,6 +59,10 @@ var Modul_klimatrend = function () {
                     var sign = text.replace(/^([+-]).*/, '$1');
                     var reading = $(this).data('get');
                     var highmark = 99;
+                    var chop = 1 * $(this).data('chop') || 0;
+                    if ( chop > 0 ) {
+                      number = 1 * text.replace(/[+-]([0-9]*)[.]([0-9]).*/, '$1.$2');
+                    }
                     if ($(this).data('highmark')) {
                         highmark = $(this).data('highmark');
                     } else {


### PR DESCRIPTION
if set >0 this option will truncate the number returned by data-get, so that minute value changes like 0.03333 are treated as stagnating values. At least for barometric values (900 to 1050 mbar) a change of 0.0333 is probably simple instrument noise ;)
TODO: make data-chop="2" keep the first 2 digits after the period...