### PR TITLE
[widget_datetimepicker] enhance handling of cell height in timepicker

### DIFF
--- a/www/tablet/js/widget_datetimepicker.js
+++ b/www/tablet/js/widget_datetimepicker.js
@@ -42,6 +42,7 @@ var Modul_datetimepicker = function () {
             elem.initData('minDate', false);
             elem.initData('maxDate', false);
             elem.initData('step', '60');
+            elem.initData('timeheightintimepicker', '30');
             me.init_attr(elem);
             console.log('minTime:',elem.data('minTime'));
             var picker = elem.datetimepicker({

--- a/www/tablet/js/widget_datetimepicker.js
+++ b/www/tablet/js/widget_datetimepicker.js
@@ -52,6 +52,7 @@ var Modul_datetimepicker = function () {
                 timepicker: elem.data('timepicker'),
                 datepicker: elem.data('datepicker'),
                 step: elem.data('step'),
+                timeHeightInTimePicker: elem.data('timeheightintimepicker'),
                 minTime: elem.data('minTime'),
                 maxTime: elem.data('maxTime'),
                 minDate: elem.data('minDate'),


### PR DESCRIPTION
This pull-request sets the `timeHeightInTimePicker` to 30 which corresponds to the height set in jquery.datetimepicker.css.

Additionally it allows to set `data-timeheightintimepicker` to set a custom height.

Both fix an issue where the current item is not displayed correctly when opening the timepicker.